### PR TITLE
Add failing test for draw by repetition

### DIFF
--- a/test/DrawByRepetitionTest.java
+++ b/test/DrawByRepetitionTest.java
@@ -1,0 +1,19 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DrawByRepetitionTest {
+    @Test
+    public void testCheckDrawByRepetition() {
+        LiteBoard board = new LiteBoard();
+        // create a simple move
+        Move move = new Move(0,0,0,1,0);
+        board.lastMove = move;
+        // simulate repeating the same move three times
+        for (int i = 0; i < 6; i++) {
+            board.history[i] = move;
+        }
+        board.numHist = 6;
+        boolean result = board.checkDrawByRepetition(board.lastMove, 3);
+        assertTrue("Draw by repetition should be detected", result);
+    }
+}


### PR DESCRIPTION
## Summary
- create `DrawByRepetitionTest` demonstrating buggy draw detection logic

## Testing
- `javac -cp target/dependency/junit-4.12.jar:target/dependency/hamcrest-core-1.3.jar -d build src/*.java test/DrawByRepetitionTest.java`
- `java -cp build:target/dependency/junit-4.12.jar:target/dependency/hamcrest-core-1.3.jar org.junit.runner.JUnitCore DrawByRepetitionTest` *(fails as expected)*