### PR TITLE
Fix move repetition detection logic

### DIFF
--- a/src/LiteBoard.java
+++ b/src/LiteBoard.java
@@ -299,13 +299,15 @@ public class LiteBoard {
 
     public boolean checkDrawByRepetition(final Move move, final int maxRepetitions) {
         // Check for draw-by-repetition (same made too many times in a row by a player)
-        int need = (int) Math.pow(2.0, (maxRepetitions + 1));
+        int need = maxRepetitions * 2;
         if (numHist < need) return false;
         int count = 0;
-        for (int i = numHist - need; i < numHist; i++) {
+        for (int i = numHist - need; i < numHist; i += 2) {
             if (history[i].equals(move)) {
                 count++;
                 if (count >= maxRepetitions) return true;
+            } else {
+                return false;
             }
         }
         return false;

--- a/src/Move.java
+++ b/src/Move.java
@@ -57,14 +57,13 @@ public class Move implements Serializable {
             return false;
         }
         Move move = (Move) o;
-        return from  == move.from
-            && to    == move.to
-            && value == move.value;
+        return from == move.from
+            && to   == move.to;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(from, to, value);
+        return Objects.hash(from, to);
     }
 
     @Override

--- a/test/DrawByRepetitionValueTest.java
+++ b/test/DrawByRepetitionValueTest.java
@@ -1,0 +1,17 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DrawByRepetitionValueTest {
+    @Test
+    public void testDifferentMoveValuesStillDraw() {
+        LiteBoard board = new LiteBoard();
+        for (int i = 0; i < 6; i++) {
+            board.history[i] = new Move(0,0,0,1,i);
+        }
+        board.numHist = 6;
+        Move last = new Move(0,0,0,1,999);
+        board.lastMove = last;
+        assertTrue("Draw should be detected despite differing move values",
+                   board.checkDrawByRepetition(last, 3));
+    }
+}


### PR DESCRIPTION
## Summary
- fix detection of repeated moves in `checkDrawByRepetition`
- ignore move value when checking equality
- add regression test for detecting repetitions when move values differ

## Testing
- `javac -cp target/dependency/*:src test/*.java src/*.java`
- `java -cp target/dependency/*:src:test org.junit.runner.JUnitCore DrawByRepetitionTest DrawByRepetitionValueTest`